### PR TITLE
Use snakemake's dependency handling, add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,23 @@ Or, just add them manually (works with any version of Sunbeam):
 
     cat $SUNBEAM_DIR/extensions/sbx_select_contigs/config.yml >> sunbeam_config.yml
     
-You need at least one BLAST database for this extension to work. The relevant config sections might look something like this:
+You need at least one BLAST database for this extension to work. The relevant sections of your `sunbeam_confif.yml` might look something like this:
 
     ...
+    
     blastdbs:
       root_fp: '/home/me/my_awesome_project'
       nucleotide:
          my_awesome_organism: 'my_awesome_organism_genomes.fasta'
+         
     ...
+    
     sbx_select_contigs:
       threads: 4
       dbname: 'my_awesome_organism'
   
 ## Running
 
-Run as usual, specifying `select_all` as the target rule, and adding `--use-conda` so that Snakemake handles all your dependencies for you:
+Run as usual, specifying `select_all` as the target rule, and adding `--use-conda` so that Snakemake handles all the extension's dependencies for you:
 
      sunbeam run --configfile sunbeam_config.yml --use_conda select_all

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Otherwise, clone the extension into your Sunbeam extensions dir:
 
 ## Initialization
 
-In Sunbeam >=3.0, to add the `sbx_select_contigs` options to your config file:
+In Sunbeam >=3.0, to add the `sbx_select_contigs` options to your config file after installing the extension:
 
     sunbeam config update -i sunbeam_config.yml
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# sbx_select_contigs
+This is an extension to the [Sunbeam metagenomics pipeline](https://github.com/sunbeam-labs/sunbeam) to extract, then coassemble (using CAP3), contigs with homology to sequences within a given BLAST database.
+
+## Install
+
+If using Sunbeam 3.0 or greater (as of Dec 2019):
+
+    sunbeam extend https://github.com/ArwaAbbas/sbx_select_contigs
+    
+Otherwise, clone the extension into your Sunbeam extensions dir:
+
+    conda activate sunbeam
+    git clone https://github.com/ArwaAbbas/sbx_select_contigs $SUNBEAM_DIR/extensions/sbx_select_contigs
+
+## Initialization
+
+In Sunbeam >=3.0, to add the `sbx_select_contigs` options to your config file:
+
+    sunbeam config update -i sunbeam_config.yml
+
+Or, just add them manually (works with any version of Sunbeam):
+
+    cat $SUNBEAM_DIR/extensions/sbx_select_contigs/config.yml >> sunbeam_config.yml
+    
+You need at least one BLAST database for this extension to work. The relevant config sections might look something like this:
+
+    ...
+    blastdbs:
+      root_fp: '/home/me/my_awesome_project'
+      nucleotide:
+         my_awesome_organism: 'my_awesome_organism_genomes.fasta'
+    ...
+    sbx_select_contigs:
+      threads: 4
+      dbname: 'my_awesome_organism'
+  
+## Running
+
+Run as usual, specifying `select_all` as the target rule, and adding `--use-conda` so that Snakemake handles all your dependencies for you:
+
+     sunbeam run --configfile sunbeam_config.yml --use_conda select_all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-cap3
-pyviko
-r-tidyverse
-r-magrittr

--- a/sbx_select_contigs_env.yml
+++ b/sbx_select_contigs_env.yml
@@ -7,3 +7,4 @@ dependencies:
   - pyviko
   - r-tidyverse
   - r-magrittr
+  - bioconductor-biostrings

--- a/sbx_select_contigs_env.yml
+++ b/sbx_select_contigs_env.yml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+  - bioconda
+  - louiejtaylor
+dependencies:
+  - cap3
+  - pyviko
+  - r-tidyverse
+  - r-magrittr

--- a/select-contig.rules
+++ b/select-contig.rules
@@ -10,6 +10,8 @@ rule find_contigs:
     params:
         scriptdir = sunbeam_dir + '/extensions/sbx_select_contigs/find_contigs.R',
         dbname = Cfg['sbx_select_contigs']['dbname']
+    conda:
+        "sbx_select_contigs_env.yml"
     shell:
         """
         Rscript {params.scriptdir} {input} {params.dbname} {output}
@@ -23,6 +25,8 @@ rule select_contigs:
         temp(str(HITS_FP/'{sample}_positive_contigs.fa'))
     params:
         scriptdir = sunbeam_dir + '/extensions/sbx_select_contigs/select_contigs.R'
+    conda:
+        "sbx_select_contigs_env.yml"
     shell:
         """
         Rscript {params.scriptdir} {input.con} {input.pos} {output}
@@ -41,6 +45,8 @@ rule combine_contigs:
         qual = str(HITS_FP/'{sample}_positive_contigs.fa.cap.contigs.qual'),
 	ace = str(HITS_FP/'{sample}_positive_contigs.fa.cap.ace'),
 	cap3dir = str(HITS_FP/'cap3/')
+    conda:
+        "sbx_select_contigs_env.yml"
     shell:
         """
         [[ -s {input} ]] && \
@@ -56,7 +62,5 @@ rule combine_contigs:
 	"""
 
 rule select_all:
-    #input:
-        #expand(str(HITS_FP/'{sample}_positive_contigs.fa'),sample = Samples.keys())
     input:
         expand(str(HITS_FP/'combined'/'{sample}_positive_contigs_final.fa'),sample = Samples.keys())


### PR DESCRIPTION
This pull request updates `sbx_select_contigs` to use Snakemake's built-in conda dependency handling so that the user doesn't have to worry about installing dependencies. I also added a quick README for this very useful extension! Thank you as always @ArwaAbbas for making my life super easy :D